### PR TITLE
Link blogpost about this app in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # issue-prioritizer
 
-This is a GitHub App built with [probot](https://probot.github.io/). It sets priority for github issues based on potential, weight and effort metrics. The principles of how it works will be described in details in blogpost later on.
+This is a GitHub App built with [probot](https://probot.github.io/). It sets priority for github issues based on potential, weight and effort metrics. Here is a blogpost that describes in details the idea and reasons behind it: [Backlog Priority Automation using Github Apps](http://techblog.holidaycheck.com/post/2018/04/11/metrics-priority).
 
 ## Setup
 


### PR DESCRIPTION
Replace a promise of blogpost to be written with an actual link to the blogpost
http://techblog.holidaycheck.com/post/2018/04/11/metrics-priority ;)